### PR TITLE
fix: savi-0000 update docker image and upgrade to fix curl issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.4.5
+FROM hashicorp/terraform:1.6.3
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \
@@ -8,7 +8,7 @@ LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       com.github.actions.icon="git-pull-request" \
       com.github.actions.color="purple"
 
-RUN apk add --no-cache -q \
+RUN apk add --no-cache -q --upgrade \
     bash \
     curl \
     jq


### PR DESCRIPTION
Updates the terraform image similar to https://github.com/robburger/terraform-pr-commenter/pull/49, also upgrades curl when installing to help mitigate the issue.